### PR TITLE
Fix issue #23

### DIFF
--- a/browse/templates/browse/datafile_detail.html
+++ b/browse/templates/browse/datafile_detail.html
@@ -44,9 +44,21 @@
   </ul>
 </div>
 
+{% if object.metadata %}
+<div class="row">
+  <pre>
+    {% autoescape on %}
+    {{ object.metadata }}
+    {% endautoescape %}
+  </pre>
+</div>
+{% endif %}
+
+{% if object.file_data %}
 <div class="row justify-content-end">
   <a class="btn btn-primary" href="{% url 'data-file-download-view' object.uuid %}">Download ({{ object.file_data.size|filesizeformat }})</a>
 </div>
+{% endif %}
 
 {% if object.dependencies.all %}
 <h2>Dependencies</h2>

--- a/browse/templates/browse/quantity_detail.html
+++ b/browse/templates/browse/quantity_detail.html
@@ -28,7 +28,7 @@
   {% for cur_obj in object.data_files.all %}
   <tr>
     <td><a href="{% url 'data-file-view' cur_obj.uuid %}">{{ cur_obj.name }}</a></td>
-    <td>{{ cur_obj.file_data.size|filesizeformat }}</td>
+    <td>{% if cur_obj.file_data %}{{ cur_obj.file_data.size|filesizeformat }}{% else %}N/A{% endif %}</td>
     <td>{{ cur_obj.upload_date|date }}, {{ cur_obj.upload_date|time }}</td>
     <td>{{ cur_obj.uuid }}</td>
   </tr>


### PR DESCRIPTION
The code in the templates checks whether data files have no file objects; in this case, they skip printing any information about the file. As this is going to happen for data files relying on metadata in JSON format, the data file page now shows a string with the metadata. 