### PR TITLE
Format JSON metadata using Highlight.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# HEAD
+
+-   Format JSON records and highlight their syntax using [Highlight.js](https://highlightjs.org/) ([PR#27](https://github.com/ziotom78/instrumentdb/pull/27))
+
+-   Increase the size of the `metadata` field for data files from 8 kB to 32 kB 
+    [0cf6cb](https://github.com/ziotom78/instrumentdb/commit/0cf6cb83766696c5471dc5ba74d14ba5d709a8f0)
+
+# Version 0.1.0
+
+- First release

--- a/browse/templates/browse/base_generic.html
+++ b/browse/templates/browse/base_generic.html
@@ -14,6 +14,10 @@
     <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/styles/github.min.css">
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/highlight.min.js"></script>
+    <script charset="utf-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/languages/json.min.js"></script>
+    <script>hljs.initHighlightingOnLoad();</script>
 
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
       <a class="navbar-brand" href="#">InstrumentDB</a>

--- a/browse/templates/browse/datafile_detail.html
+++ b/browse/templates/browse/datafile_detail.html
@@ -1,5 +1,7 @@
 {% extends "browse/base_generic.html" %}
 
+{% load customfilters %}
+
 {% block title %}{{ object.name }}{% endblock %}
 
 {% block body %}
@@ -47,9 +49,11 @@
 {% if object.metadata %}
 <div class="row">
   <pre>
-    {% autoescape on %}
-    {{ object.metadata }}
-    {% endautoescape %}
+    <code class="json">
+{% autoescape on %}
+{{ object.metadata|format_json }}
+{% endautoescape %}
+    </code>
   </pre>
 </div>
 {% endif %}

--- a/browse/templatetags/customfilters.py
+++ b/browse/templatetags/customfilters.py
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+
+# See the Django docs to understand how this works:
+# https://docs.djangoproject.com/en/3.0/howto/custom-template-tags/
+
+import json
+
+from django import template
+from django.template.defaultfilters import stringfilter
+
+register = template.Library()
+
+
+@register.filter
+@stringfilter
+def format_json(value):
+    try:
+        d = json.loads(value)
+        return json.dumps(d, indent=4)
+    except json.JSONDecodeError:
+        pass
+
+    return value


### PR DESCRIPTION
This PR uses [Highlight.js](https://highlightjs.org/) and some Django trickery to format JSON records nicely:

![deleteme_instrumentdb_json](https://user-images.githubusercontent.com/377795/84473616-ae1f3800-ac89-11ea-810c-ca0ff2f7e9ff.png)
