### PR TITLE
Use JSON instead of YAML for importing/exporting the database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+-   Make JSON the default format when importing/exporting the database [PR#28](https://github.com/ziotom78/instrumentdb/pull/28)
+
 -   Format JSON records and highlight their syntax using [Highlight.js](https://highlightjs.org/) ([PR#27](https://github.com/ziotom78/instrumentdb/pull/27))
 
 -   Increase the size of the `metadata` field for data files from 8 kB to 32 kB 

--- a/browse/management/commands/export.py
+++ b/browse/management/commands/export.py
@@ -254,10 +254,10 @@ class Command(BaseCommand):
         )
 
         with output_file_path.open("w") as outf:
-            if self.use_json:
-                json.dump(schema, outf, indent=2)
-            else:
+            if self.output_file_path.suffix == ".yaml":
                 yaml_saner_dump(schema, stream=outf)
+            else:
+                json.dump(schema, outf, indent=2)
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -271,6 +271,12 @@ class Command(BaseCommand):
             action="store_true",
             help="Use JSON as the format of the file containing the schema "
             "(always true)",
+        )
+        parser.add_argument(
+            "--yaml",
+            action="store_true",
+            help="Save a copy of the schema using the YAML format (useful "
+            "for legacy codes)",
         )
         parser.add_argument(
             "--force",
@@ -294,9 +300,12 @@ If the folder does not exist, it will be created.""",
         # Create the output directory
         self.output_folder.mkdir(parents=True, exist_ok=self.exist_ok)
 
+        extensions = []
         if self.use_json:
-            ext = "json"
-        else:
-            ext = "yaml"
+            extensions.append("json")
 
-        self.save_schema(self.output_folder / f"schema.{ext}")
+        if self.use_yaml:
+            extensions.append("yaml")
+
+        for cur_ext in extensions:
+            self.save_schema(self.output_folder / f"schema.{cur_ext}")

--- a/browse/management/commands/exportyaml.py
+++ b/browse/management/commands/exportyaml.py
@@ -103,7 +103,7 @@ class Command(BaseCommand):
         result = []
         for cur_entity in entities:
             # We use a OrderedDict here because otherwise "children" would
-            # be the first key in the YAML file, and this would make the
+            # be the first key in the JSON file, and this would make the
             # file harder to read
             new_element = OrderedDict(
                 [("uuid", Quoted(cur_entity.uuid)), ("name", Quoted(cur_entity.name))]
@@ -263,13 +263,14 @@ class Command(BaseCommand):
         parser.add_argument(
             "--no-attachments",
             action="store_true",
-            help="Do not save data files, only the YAML file",
+            help="Do not save data files, only the JSON file",
         )
         parser.add_argument(
             "--json",
+            default=True,
             action="store_true",
-            help="Use JSON instead of YAML as the format of the file "
-            "containing the schema",
+            help="Use JSON as the format of the file containing the schema "
+            "(always true)",
         )
         parser.add_argument(
             "--force",

--- a/browse/management/commands/import.py
+++ b/browse/management/commands/import.py
@@ -37,7 +37,7 @@ def build_query_from_uuid_or_name(key, name_field="name"):
 
 
 class Command(BaseCommand):
-    help = "Load records into the database from a YAML file"
+    help = "Load records into the database from a JSON file"
     output_transaction = True
     requires_migrations_checks = True
 
@@ -337,9 +337,7 @@ class Command(BaseCommand):
             help="Do not execute any action on the database (useful for testing)",
         )
         parser.add_argument(
-            "--json",
-            action="store_true",
-            help="Read the schema from a JSON file instead of a YAML file",
+            "--json", action="store_true", help="Unused",
         )
         parser.add_argument(
             "--no-overwrite",
@@ -366,14 +364,14 @@ etc.) will be looked in the directory where this file resides.
             schema_filename = Path(curfile)
 
             # Retrieve every attachment from the same path where the
-            # YAML file is
+            # JSON file is
             self.attachment_source_path = schema_filename.parent
 
-            with open(schema_filename, "rt") as inpf:
-                if self.use_json:
-                    schema = json.load(inpf)
-                else:
+            with schema_filename.open("rt") as inpf:
+                if schema_filename.suffix == ".yaml":
                     schema = yaml.safe_load(inpf)
+                else:
+                    schema = json.load(inpf)
 
             self.create_format_specifications(schema.get("format_specifications", []))
             self.create_entities(schema.get("entities", []))

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -171,6 +171,11 @@ Open a text editor and write the following YAML text:
         doc_file: "tutorial_bandshapes.pdf"
 
 Save this into a file named :file:`tutorial.yaml`.
+        
+(Note: JSON is much faster to load than YAML, and it should be
+preferred. We are using YAML here because it looks cleaner to read.
+InstrumentDB transparently supports both JSON and YAML.)
+
 
 Organization of entities and quantities
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -203,11 +208,12 @@ In our example, we might think of the following structure for our entities:
 
     - Bandshape response (quantity)
 
-The safest way to define the structure of entities is through a YAML file.
-InstrumentDB has the ability to read a YAML file and populate the database
-with its contents. Users have still the possibility to manually create
-each entity and quantity using the web interface, but for deeply-nested
-structures like the one above, it is better to go through a text file.
+The safest way to define the structure of entities is through a YAML
+file. InstrumentDB has the ability to read a YAML/JSON file and
+populate the database with its contents. Users have still the
+possibility to manually create each entity and quantity using the web
+interface, but for deeply-nested structures like the one above, it is
+better to go through a text file.
 
 Append the following text at the bottom of file :file:`tutorial.yaml`:
 
@@ -255,7 +261,7 @@ files containing the specification documents (e.g.,
 :file:`tutorial.yaml` that is contained in the :file:`examples`
 directory. Run the following command::
 
-  poetry run manage.py importyaml examples/tutorial.yaml
+  poetry run manage.py import examples/tutorial.yaml
 
 .. warning::
 

--- a/tests/test_import_commands.py
+++ b/tests/test_import_commands.py
@@ -21,7 +21,7 @@ class TestNestedYamlIO(TestCase):
         input_file = Path(__file__).parent / ".." / "examples" / "schema1.yaml"
 
         # Test a dry run
-        call_command("importyaml", "--dry-run", input_file)
+        call_command("import", "--dry-run", input_file)
         check_db_size(
             self,
             entity_len=0,
@@ -32,7 +32,7 @@ class TestNestedYamlIO(TestCase):
         )
 
         # Test a normal import
-        call_command("importyaml", input_file)
+        call_command("import", input_file)
         check_db_size(
             self,
             entity_len=12,
@@ -43,7 +43,7 @@ class TestNestedYamlIO(TestCase):
         )
 
         # Test that --no-overwrite works
-        call_command("importyaml", "--no-overwrite", input_file)
+        call_command("import", "--no-overwrite", input_file)
         check_db_size(
             self,
             entity_len=12,
@@ -57,7 +57,7 @@ class TestNestedYamlIO(TestCase):
 class TestPlainYamlIO(TestCase):
     def test_import_plain_yaml(self):
         input_file = Path(__file__).parent / ".." / "examples" / "schema2.yaml"
-        call_command("importyaml", input_file)
+        call_command("import", input_file)
         check_db_size(
             self,
             entity_len=12,
@@ -71,7 +71,7 @@ class TestPlainYamlIO(TestCase):
 class TestTutorial(TestCase):
     def test_import_tutorial(self):
         input_file = Path(__file__).parent / ".." / "examples" / "tutorial.yaml"
-        call_command("importyaml", input_file)
+        call_command("import", input_file)
         check_db_size(
             self,
             entity_len=6,


### PR DESCRIPTION
This should fix issue #26. Things done in this PR:

- [x] Rename `exportyaml` to `export`
- [x] Rename `importyaml` to `import`
- [x] Fix tests
- [x] Update the documentation
