### PR TITLE
Add link to Releases webpage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+-   Add link to the «Releases» page in the top bar and some more release information to the data file view [#40](https://github.com/ziotom78/instrumentdb/pull/40)
+
 -   Fix bug [#37](https://github.com/ziotom78/instrumentdb/issues/37)
 
 # Version 0.4.0

--- a/browse/models.py
+++ b/browse/models.py
@@ -36,7 +36,14 @@ from mptt.models import MPTTModel, TreeForeignKey
 
 from instrumentdb.settings import STORAGE_PATH
 
-FileType = namedtuple("ImageFileType", ["mime_type", "file_extension", "description",])
+FileType = namedtuple(
+    "ImageFileType",
+    [
+        "mime_type",
+        "file_extension",
+        "description",
+    ],
+)
 
 # List of supported document types (for specification documents).
 # Please keep the most useful at the top of the list, then use
@@ -355,6 +362,12 @@ class DataFile(models.Model):
             "name",
             "uuid",
         )
+
+    @property
+    def full_path(self):
+        entity = self.quantity.parent_entity
+        ancestors = entity.get_ancestors(include_self=True)
+        return "/".join([x.name for x in ancestors]) + "/" + self.name
 
 
 class Release(models.Model):

--- a/browse/templates/browse/base_generic.html
+++ b/browse/templates/browse/base_generic.html
@@ -40,6 +40,11 @@
             </a>
           </li>
           <li class="nav-item">
+            <a class="nav-link" href="{% url 'release-list-view' %}">
+              Releases
+            </a>
+          </li>
+          <li class="nav-item">
             <a class="nav-link" href="{% url 'format-spec-list-view' %}">
               Format specifications
             </a>

--- a/browse/templates/browse/datafile_detail.html
+++ b/browse/templates/browse/datafile_detail.html
@@ -64,6 +64,32 @@
 </div>
 {% endif %}
 
+{% if object.release_tags.all %}
+<h2>Releases</h2>
+
+<table  class="table">
+  <thead>
+    <th scope="col">Release</th>
+    <th scope="col">Date</th>
+    <th scope="col">Object's path</th>
+  </thead>
+  
+  {% for cur_release in object.release_tags.all %}
+  <tr>
+    <td>
+      <a href="{% url 'release-view' cur_release.tag %}">{{ cur_release.tag }}</a>
+    </td>
+    <td>
+      {{ cur_release.rel_date|date:"M d, Y" }}
+    </td>
+    <td>
+      <tt>/releases/{{ cur_release.tag}}/{{ object.full_path }}</tt>
+    </td>
+  </tr>
+  {% endfor %}
+</table>
+{% endif %}
+
 {% if object.dependencies.all %}
 <h2>Dependencies</h2>
 


### PR DESCRIPTION
This PR adds a link to the «Releases» webpage in the top bar of the website.
