### PR TITLE
Fix permissions in the Release page

### DIFF
--- a/browse/views.py
+++ b/browse/views.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from django.contrib.auth import authenticate
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponse
 from django.utils.datetime_safe import datetime
 from django.utils.timezone import utc
@@ -141,7 +142,7 @@ class DataFilePlotDownloadView(View):
 ###########################################################################
 
 
-class ReleaseListView(ListView):
+class ReleaseListView(LoginRequiredMixin, ListView):
     model = Release
 
     ordering = ["-tag"]


### PR DESCRIPTION
This PR implements a patch by Daniele Navarra. It blocks access to the Home page (the list of releases) unless the user has successfully logged in.
