### PR TITLE
Add ability to turn on logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
 DEBUG=on
+LOGGING=on
+LOG_FILE_PATH=/my/storage/logs/instrumentdb.log
+LOG_LEVEL=INFO
 SECRET_KEY=""
 ALLOWED_HOSTS='localhost,127.0.0.1,[::1]'
 STORAGE_PATH=/my/storage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+-   Add the ability to enable logging [#78](https://github.com/ziotom78/instrumentdb/pull/78)
+
 -   Add the `--only-tree` switch to the `export` command [#77](https://github.com/ziotom78/instrumentdb/pull/77)
 
 -   Remove LiteBIRD-related stuff [#76](https://github.com/ziotom78/instrumentdb/pull/76)

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -13,3 +13,15 @@ file. Here are the key values that you should modify:
 
 - Turn on ``LOGGING`` and specify a path where logging messages should be saved using the field
   ``LOG_FILE_PATH``; be sure that the directory where you save this file is writable.
+
+- Set up the logging level according to your tastes, using the field ``LOG_LEVEL``. Valid values are:
+
+  1. ``DEBUG``
+  2. ``INFO``
+  3. ``WARNING``
+
+As an example, here is the section of a ``.env`` file where logging is configured::
+
+    LOGGING=on
+    LOG_FILE_PATH=/var/log/instrumentdb/instrumentdb.log
+    LOG_LEVEL=INFO

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -1,0 +1,15 @@
+Deployment
+==========
+
+The command ``python3 manage runserver`` is useful to check that the site looks ok, but it should not be
+used in production, because the Django server is highly inefficient. You should rely on well-tested servers like
+`Apache <https://httpd.apache.org/>`_ or `Nginx <https://www.nginx.com/>`_.
+
+To publish your site so that other people can access it, you must properly set up a few critical entries in the ``.env``
+file. Here are the key values that you should modify:
+
+- Always set ``DEBUG`` to ``off``, otherwise any failure in the code will reveal important details about
+  the internals of your site (e.g., secret keys, local paths…).
+
+- Turn on ``LOGGING`` and specify a path where logging messages should be saved using the field
+  ``LOG_FILE_PATH``; be sure that the directory where you save this file is writable.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Welcome to InstrumentDB's documentation!
    tutorial
    releases
    webapi
+   deployment
    
 Indices and tables
 ==================

--- a/instrumentdb/settings.py
+++ b/instrumentdb/settings.py
@@ -40,6 +40,31 @@ DEBUG = env("DEBUG")
 ALLOWED_HOSTS = env("ALLOWED_HOSTS")
 MEDIA_ROOT = Path(env("STORAGE_PATH"))
 
+if env.bool("LOGGING"):
+    LOGGING = {
+        'version': 1,
+        'disable_existing_loggers': False,
+        'handlers': {
+            'file': {
+                'level': env("LOG_LEVEL"),
+                'class': 'logging.FileHandler',
+                'filename': env("LOG_FILE_PATH"),
+            },
+        },
+        'loggers': {
+            'django': {
+                'handlers': ['file'],
+                'level': env("LOG_LEVEL"),
+                'propagate': True,
+            },
+        },
+    }
+
+    # Ensure that the directory where the log file is to be create exists
+    log_file_path = Path(LOGGING["handlers"]["file"]["filename"])
+    log_file_path.parent.mkdir(parents=True, exist_ok=True)
+
+
 # Application definition
 
 INSTALLED_APPS = [


### PR DESCRIPTION
This PR add a few flags to the `.env` file to specify how logging should be implemented:

-   `LOGGING`: it can either be `on` or `off`
-   `LOG_FILE_PATH`: absolute path to the file that will contain the log messages
-   `LOG_LEVEL`: a string identifying the logging level