### PR TITLE
Add LOG_FORMATTER and the ability to send log msgs to console

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 DEBUG=on
 LOGGING=on
 LOG_FILE_PATH=/my/storage/logs/instrumentdb.log
+LOG_FORMATTER=brief
 LOG_LEVEL=INFO
 SECRET_KEY=""
 ALLOWED_HOSTS='localhost,127.0.0.1,[::1]'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+-   Add the ability to send log messages to the console [#80](https://github.com/ziotom78/instrumentdb/pull/80)
+
 -   Stop using the old `uuid` external package [#79](https://github.com/ziotom78/instrumentdb/pull/79)
 
 -   Add the ability to enable logging [#78](https://github.com/ziotom78/instrumentdb/pull/78)

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -12,7 +12,9 @@ file. Here are the key values that you should modify:
   the internals of your site (e.g., secret keys, local paths…).
 
 - Turn on ``LOGGING`` and specify a path where logging messages should be saved using the field
-  ``LOG_FILE_PATH``; be sure that the directory where you save this file is writable.
+  ``LOG_FILE_PATH``; leave it out of the file if you want to send messages to the console. (This can be useful if
+  your webserver already redirects console messages to a log file.) You can specify the style of the
+  messages using the ``LOG_FORMATTER`` variable; it can either be ``brief`` (the default) or ``verbose``.
 
 - Set up the logging level according to your tastes, using the field ``LOG_LEVEL``. Valid values are:
 
@@ -24,4 +26,5 @@ As an example, here is the section of a ``.env`` file where logging is configure
 
     LOGGING=on
     LOG_FILE_PATH=/var/log/instrumentdb/instrumentdb.log
+    LOG_FORMATTER=verbose
     LOG_LEVEL=INFO


### PR DESCRIPTION
This PR enables to send log messages to the console; either set `LOG_FILE_PATH` to the empty string or leave it out of the `.env` file. A new variable, `LOG_FORMATTER`, enables to switch between “short” (`brief`) and “long” (`verbose`) messages.