### PR TITLE
Add flag in .env file to configure STATIC_ROOT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,4 @@ SECRET_KEY=""
 ALLOWED_HOSTS='localhost,127.0.0.1,[::1]'
 STORAGE_PATH=/my/storage
 DATABASE_URL=/my/storage/instrumentdb.sqlite3
+STATIC_PATH=/my/static/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+-   Add the ability to configure where to keep static files [#82](https://github.com/ziotom78/instrumentdb/pull/82)
+
 -   Add the ability to send log messages to the console [#80](https://github.com/ziotom78/instrumentdb/pull/80)
 
 -   Stop using the old `uuid` external package [#79](https://github.com/ziotom78/instrumentdb/pull/79)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # HEAD
 
--   Add the ability to configure where to keep static files [#82](https://github.com/ziotom78/instrumentdb/pull/82)
-
 -   Add the ability to send log messages to the console [#80](https://github.com/ziotom78/instrumentdb/pull/80)
 
 -   Stop using the old `uuid` external package [#79](https://github.com/ziotom78/instrumentdb/pull/79)

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -22,9 +22,15 @@ file. Here are the key values that you should modify:
   2. ``INFO``
   3. ``WARNING``
 
-As an example, here is the section of a ``.env`` file where logging is configured::
+  As an example, here is the section of a ``.env`` file where logging is configured::
 
     LOGGING=on
     LOG_FILE_PATH=/var/log/instrumentdb/instrumentdb.log
     LOG_FORMATTER=verbose
     LOG_LEVEL=INFO
+
+- Set up a folder where to keep static files, e.g., ``/var/www/static``, and specify its path in the
+  ``.env`` file, under the name ``STATIC_PATH``. Then, every time you update the site, be sure to
+  run ``python3 manage.py collectstatic``, so that the path is filled with static files (images, CSS, etc.).
+  You should make your webserver publish this folder under the URL ``/static``; see the `Django documentation
+  <https://docs.djangoproject.com/en/4.1/howto/deployment/wsgi/modwsgi/#serving-files>`_ for an example.

--- a/instrumentdb/settings.py
+++ b/instrumentdb/settings.py
@@ -196,7 +196,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.0/howto/static-files/
 
 STATIC_URL = "static/"
-STATIC_ROOT = os.path.join(BASE_DIR, "static")
+STATIC_ROOT = env("STATIC_PATH", default=os.path.join(BASE_DIR, "static"))
 LOGIN_REDIRECT_URL = "/accounts/login/"
 LOGOUT_REDIRECT_URL = "/"
 ADMIN_MEDIA_PREFIX = "/static/admin/"


### PR DESCRIPTION
This PR implements `STATIC_PATH`, a new flag in file `.env` that sets the value of the Django internal variable `STATIC_ROOT`. It can be used when you publish a site and want to keep static files separated from the main webserver.
