### PR TITLE
Raise a HTTP error 404 if a file is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+-   Raise a HTTP 404 error if the user asks to download a file that was not uploaded to the database [#87](https://github.com/ziotom78/instrumentdb/pull/87)
+
 -   Let the user change their own passwords [#85](https://github.com/ziotom78/instrumentdb/pull/85)
 
 # Version 1.1.0

--- a/browse/views.py
+++ b/browse/views.py
@@ -8,7 +8,7 @@ from django.contrib.auth import authenticate
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import ObjectDoesNotExist
-from django.http import HttpResponse
+from django.http import HttpResponse, Http404
 from django.utils.datetime_safe import datetime
 from django.utils.timezone import utc
 from django.views.generic.base import View
@@ -128,7 +128,14 @@ class FormatSpecificationDownloadView(View):
 
         cur_object = get_object_or_404(FormatSpecification, pk=pk)
         file_data = cur_object.doc_file
-        file_data.open()
+
+        try:
+            file_data.open()
+        except ValueError:
+            raise Http404(
+                "The format specification file was not uploaded to the database"
+            )
+
         data = file_data.read()
         resp = HttpResponse(data, content_type=cur_object.doc_mime_type)
         resp["Content-Disposition"] = 'attachment; filename="{0}"'.format(
@@ -143,7 +150,11 @@ class DataFileDownloadView(View):
 
         cur_object = get_object_or_404(DataFile, pk=pk)
         file_data = cur_object.file_data
-        file_data.open()
+        try:
+            file_data.open()
+        except ValueError:
+            raise Http404("The data file was not uploaded to the database")
+
         data = file_data.read()
         resp = HttpResponse(
             data, content_type=cur_object.quantity.format_spec.file_mime_type
@@ -160,7 +171,12 @@ class DataFilePlotDownloadView(View):
 
         cur_object = get_object_or_404(DataFile, pk=pk)
         plot_file_data = cur_object.plot_file
-        plot_file_data.open()
+
+        try:
+            plot_file_data.open()
+        except ValueError:
+            raise Http404("The plot file was not uploaded to the database")
+
         data = plot_file_data.read()
         resp = HttpResponse(data, content_type=cur_object.plot_mime_type)
 


### PR DESCRIPTION
This PR fixes those exceptions that are raised if a file (format specification/data file/plot file) is not present on disk. The new behavior is to raise a HTTP 404 error, which is semantically more correct.
