### PR TITLE
Clean up the documentation and the source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+-   Clean up the documentation [#89](https://github.com/ziotom78/instrumentdb/pull/89)
+
 -   Raise a HTTP 404 error if the user asks to download a file that was not uploaded to the database [#87](https://github.com/ziotom78/instrumentdb/pull/87)
 
 -   Let the user change their own passwords [#85](https://github.com/ziotom78/instrumentdb/pull/85)

--- a/browse/models.py
+++ b/browse/models.py
@@ -38,19 +38,10 @@ from typing import Optional
 import git
 import json
 import yaml
-from django.contrib.auth.base_user import AbstractBaseUser
-from django.contrib.auth.decorators import login_required
 from django.core.files import File
 from django.db import models
 from django.utils import timezone
 from mptt.models import MPTTModel, TreeForeignKey
-from rest_framework import permissions
-from rest_framework.decorators import permission_classes
-from rest_framework.permissions import IsAuthenticated
-from django.conf import settings
-from django.db.models.signals import post_save
-from django.dispatch import receiver
-from rest_framework.authtoken.models import Token
 
 from instrumentdb import __version__
 
@@ -790,5 +781,5 @@ def update_release_file_dumps(force: bool = False):
             with json_file_path.open("rt") as json_file:
                 cur_release.json_file.save(
                     name=f"schema_{cur_release.tag}.json",
-                    content=DjangoFile(json_file),
+                    content=open(json_file, "rb"),
                 )

--- a/browse/serializers.py
+++ b/browse/serializers.py
@@ -2,7 +2,7 @@
 
 import json
 
-from rest_framework import serializers, request
+from rest_framework import serializers
 from rest_framework.reverse import reverse
 from django.contrib.auth.models import User, Group
 from browse.models import Entity, Quantity, DataFile, FormatSpecification, Release
@@ -32,10 +32,16 @@ class FormatSpecificationSerializer(serializers.HyperlinkedModelSerializer):
             "url",
             "document_ref",
             "title",
+            "doc_file",
             "doc_file_name",
             "doc_mime_type",
             "file_mime_type",
         ]
+        extra_kwargs = {
+            "doc_file": {
+                "max_length": 512,
+            }
+        }
 
     def to_representation(self, instance):
         representation = super(FormatSpecificationSerializer, self).to_representation(

--- a/browse/views.py
+++ b/browse/views.py
@@ -17,9 +17,10 @@ from django.views.generic.list import ListView
 from django.contrib.auth.models import User, Group
 from django.shortcuts import render, redirect, get_object_or_404
 
-from rest_framework import viewsets, authentication, permissions
+from rest_framework import viewsets, permissions
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import api_view, permission_classes
+from rest_framework.mixins import UpdateModelMixin
 
 import instrumentdb
 from browse.models import Entity, Quantity, DataFile, FormatSpecification, Release
@@ -45,6 +46,8 @@ from instrumentdb.authentication import (
     expires_in,
     is_token_expired,
 )
+
+ADMIN_ONLY_HTTP_METHODS = ["POST", "PUT", "PATCH", "DELETE"]
 
 mimetypes.init()
 
@@ -258,10 +261,11 @@ class FormatSpecificationViewSet(viewsets.ModelViewSet):
         instrumentdb.authentication.ExpiringTokenAuthentication,
         SessionAuthentication,
     ]
+
     # permission_classes = [permissions.IsAuthenticated]
 
     def get_permissions(self):
-        if self.request.method in ["PUT", "DELETE"]:
+        if self.request.method in ADMIN_ONLY_HTTP_METHODS:
             return [permissions.IsAdminUser()]
         return [permissions.IsAuthenticated()]
 
@@ -280,7 +284,7 @@ class EntityViewSet(viewsets.ModelViewSet):
     # permission_classes = [permissions.IsAuthenticated]
 
     def get_permissions(self):
-        if self.request.method in ["PUT", "DELETE"]:
+        if self.request.method in ADMIN_ONLY_HTTP_METHODS:
             return [permissions.IsAdminUser()]
         return [permissions.IsAuthenticated()]
 
@@ -298,7 +302,7 @@ class QuantityViewSet(viewsets.ModelViewSet):
     # permission_classes = [permissions.IsAuthenticated]
 
     def get_permissions(self):
-        if self.request.method in ["PUT", "DELETE"]:
+        if self.request.method in ADMIN_ONLY_HTTP_METHODS:
             return [permissions.IsAdminUser()]
         return [permissions.IsAuthenticated()]
 
@@ -314,7 +318,7 @@ class DataFileViewSet(viewsets.ModelViewSet):
     # permission_classes = [permissions.IsAuthenticated]
 
     def get_permissions(self):
-        if self.request.method in ["PUT", "DELETE"]:
+        if self.request.method in ADMIN_ONLY_HTTP_METHODS:
             return [permissions.IsAdminUser()]
         return [permissions.IsAuthenticated()]
 
@@ -333,7 +337,7 @@ class ReleaseViewSet(viewsets.ModelViewSet):
     # permission_classes = [permissions.IsAuthenticated]
 
     def get_permissions(self):
-        if self.request.method in ["PUT", "DELETE"]:
+        if self.request.method in ADMIN_ONLY_HTTP_METHODS:
             return [permissions.IsAdminUser()]
         return [permissions.IsAuthenticated()]
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -401,6 +401,10 @@ we create the same object structure as the one above::
   server_url = "http://127.0.0.1:8000"
   
   # Get authentication token (login)
+  # For security reasons, you should store both username
+  # and password in a separate text file and read it before
+  # calling the following "req.post()" statement. We'll
+  # keep things simple here
   response = req.post(url=f"{server_url}/api/login",
       data={"username":"user1", "password": "passwd54321"}
   )
@@ -416,6 +420,9 @@ we create the same object structure as the one above::
   auth_header = {"Authorization": f"Token {token}"}
   
   # Create a new entity in the database
+  # Note that if you forget the `headers=auth_header` part,
+  # this command will halt with a HTTP 401 error (unauthorized
+  # request)
   response = req.post(
       url=f"{server_url}/api/entities/",
       data={ "name": "foo_python", "parent": None },

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,3 +40,10 @@ sqlparse==0.4.4 ; python_version >= "3.7" and python_version < "4.0"
 typing-extensions==4.3.0 ; python_version >= "3.7" and python_version < "3.8"
 urllib3==1.26.11 ; python_version >= "3.7" and python_version < "4"
 zipp==3.8.1 ; python_version >= "3.7" and python_version < "3.10"
+
+Django~=3.2.19
+djangorestframework~=3.13.1
+PyYAML~=5.4.1
+django-mptt~=0.11.0
+envparse~=0.2.0
+pytz~=2022.1


### PR DESCRIPTION
Several examples in the documentation were outdated, and the code was full of unused imports. Format specifications should be easier to upload now.
