### PR TITLE
Add command `delete-data-files`

### DIFF
--- a/browse/management/commands/delete-data-files.py
+++ b/browse/management/commands/delete-data-files.py
@@ -1,0 +1,88 @@
+# -*- encoding: utf-8 -*-
+
+from django.core.management.base import BaseCommand
+from browse.models import DataFile, Release
+
+
+class Command(BaseCommand):
+    help = "Delete data files from the database"
+    output_transaction = True
+    requires_migrations_checks = True
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--release",
+            action="append",
+            type=str,
+            help="Delete all the objects in the matching release. "
+            "This switch can be repeated.",
+        )
+        parser.add_argument(
+            "--from-file",
+            type=str,
+            help="Read the UUIDs of the objects to be deleted from file (one UUID per line)",
+        )
+        parser.add_argument(
+            "uuids",
+            nargs="*",
+            type=str,
+            help="""List of the UUIDs of the data files to be removed""",
+        )
+
+    def handle(self, *args, **options):
+        from uuid import UUID
+        import time
+
+        ######################################################
+        # Let's build the list of UUIDs to delete.
+
+        # First comes the plain list of UUIDs provided through the command line
+        list_of_uuids = [UUID(x) for x in options["uuids"]]
+
+        # Then the UUIDs provided through a file
+        if options.get("from_file", None) is not None:
+            with open(options["from_file"], "rt") as input_file:
+                list_of_uuids += [UUID(x.strip()) for x in input_file.readlines()]
+
+        # Next the list of releases
+        releases = options.get("release", [])
+        num_of_objects_in_releases = {}
+        if releases:
+            for cur_release in releases:
+                cur_num = 0
+                for cur_obj in DataFile.objects.filter(release_tags=cur_release):
+                    # Only delete this object if it does not belong to any
+                    # other release, otherwise there would be dangling references
+                    if len(cur_obj.release_tags.all()) == 1:
+                        list_of_uuids.append(cur_obj.pk)
+                        cur_num += 1
+
+                if cur_num > 0:
+                    num_of_objects_in_releases[cur_release] = cur_num
+
+        ########################################################
+        # Delete the objects
+
+        queryset = DataFile.objects.filter(pk__in=list_of_uuids)
+
+        num_of_objects = len(queryset)
+        if num_of_objects == 0:
+            print(
+                f"No objects matching the {len(list_of_uuids)} UUID(s) have been found"
+            )
+            return
+
+        print(
+            f"Found {num_of_objects} data file(s) out of {len(list_of_uuids)}"
+        )
+
+        start_time = time.monotonic()
+        queryset.delete()
+        end_time = time.monotonic()
+        print(
+            f"The {num_of_objects} object(s) have been deleted in {end_time - start_time:.2f} s"
+        )
+
+        for cur_release, cur_num_of_objs in num_of_objects_in_releases.items():
+            Release.objects.filter(tag=cur_release).delete()
+            print(f"Release {cur_release} deleted, it contained {cur_num_of_objs} data files")

--- a/docs/commandline.rst
+++ b/docs/commandline.rst
@@ -1,0 +1,67 @@
+Commands
+========
+
+InstrumentDB implements a number of commands that can be executed from
+the terminal. These are meant to ease the management of the database.
+
+Here is the list:
+
+- :ref:`export_cmd`
+- :ref:`import_cmd`
+- :ref:`updatedb_cmd`
+- :ref:`deletedatafiles_cmd`
+
+These commands can be executed from the command line using the syntax
+
+.. code-block::
+
+   python3 manage.py CMD
+
+where ``CMD`` is the name of the command, e.g., ``export``. To get
+help for the command, run
+
+.. code-block::
+
+   python3 manage.py CMD --help
+
+
+.. _export_cmd:
+``export``
+----------
+
+This command exports the content of the database into a folder.
+The index of the database, all the metadata, the release information
+and so on are stored in a file named ``schema.json``, while all the
+data files, format specifications, plots, etc., are saved in separate
+directories.
+
+The purpose of the ``export`` command is to be paired with ``import``:
+it enables a database to be created on a machine and replicated into
+another.
+
+
+.. _import_cmd:
+``import``
+----------
+
+This command imports a JSON file and the associated files that have
+been produced by the :ref:`_export_cmd` command.
+
+
+.. _updatedb_cmd:
+``updatedb``
+------------
+
+The database keeps a copy of every release in the form of a JSON file.
+This command rebuilds all these JSON files. It should be triggered
+if you fear that these files got corrupted.
+
+
+.. _deletedatafiles_cmd:
+``delete-data-files``
+---------------------
+
+Delete a set of data files from the database. You can specify a release tag
+using the ``--release`` command-line switch: in this case, all the data files
+belonging to the data release will be deleted. Any data file belonging to more
+than one data release will be left untouched.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Welcome to InstrumentDB's documentation!
    tutorial
    releases
    webapi
+   commandline
    customization
    deployment
    


### PR DESCRIPTION
This PR implements the command `delete-data-files`, which can be used to delete
data files or entire releases. To get help, run the following command:

    python3 manage.py delete-data-files

