### PR TITLE
Add validation of JSON metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+-   Validate the `metadata` field of data files [#92](https://github.com/ziotom78/instrumentdb/pull/92)
+
 -   Implement the `delete-all` command [#91](https://github.com/ziotom78/instrumentdb/pull/91)
 
 -   Implement the `delete-data-files` command [#90](https://github.com/ziotom78/instrumentdb/pull/90)


### PR DESCRIPTION
This PR adds a check that verifies that the field "metadata" of a data file is valid JSON, and it rejects any POST/PUT command that does not pass the check.
