### PR TITLE
Make the entity tree collapsible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+-   The tree of entities is now collapsible [#94](https://github.com/ziotom78/instrumentdb/pull/94)
+
 -   Extend test coverage, fix issues in the code [#93](https://github.com/ziotom78/instrumentdb/pull/93)
 
 -   Validate the `metadata` field of data files [#92](https://github.com/ziotom78/instrumentdb/pull/92)

--- a/browse/templates/browse/entity_list.html
+++ b/browse/templates/browse/entity_list.html
@@ -9,14 +9,14 @@
   <ul class="list-group list-group-flush">
     {% recursetree object_list %}
     <li class="list-group-item">
-      <div class="media-body">
-        <a href="{% url 'entity-view' node.uuid %}">{{ node.name|capfirst }}</a>
+      <details>
+        <summary><a href="{% url 'entity-view' node.uuid %}">{{ node.name|capfirst }}</a></summary>
         {% if not node.is_leaf_node %}
-        <ul class="children">
+        <ul class="children nested">
           {{ children }}
         </ul>
         {% endif %}
-      </div>
+      </details>
     </li>
     {% endrecursetree %}
   </ul>


### PR DESCRIPTION
This PR makes the entity tree collapsible using the HTML `<detail>` tag.

Here is an example:

![collapsible-trees](https://github.com/ziotom78/instrumentdb/assets/377795/6cf692eb-6b37-4fb4-98fb-f58d48f2d80d)
