### PR TITLE
Make the download of format specs easier and more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+-   Make the download of specification documents easier [#97](https://github.com/ziotom78/instrumentdb/pull/97)
+
 -   Implement release documents, support Django 4 [#96](https://github.com/ziotom78/instrumentdb/pull/96)
 
 -   The URL `/api/releases` now uses pagination [#95](https://github.com/ziotom78/instrumentdb/pull/95)

--- a/browse/templates/browse/formatspecification_list.html
+++ b/browse/templates/browse/formatspecification_list.html
@@ -17,7 +17,7 @@
   {% for spec in object_list %}
   <tr>
     <td>
-      <a href="{% url 'format-spec-download-view' spec.uuid %}">{{ spec.title }}</a>
+      <a href="{% url 'format-spec-download-view' spec.uuid %}" target="_blank" rel="noopener noreferrer">{{ spec.title }}</a>
     </td>
     <td>{{ spec.document_ref}}</td>
     <td>{{ spec.file_mime_type }}</td>

--- a/browse/templates/browse/quantity_detail.html
+++ b/browse/templates/browse/quantity_detail.html
@@ -6,7 +6,7 @@
 
 <ul>
   <li>Format specification:
-    <a href="{% url 'format-spec-download-view' object.format_spec.uuid %}">
+    <a href="{% url 'format-spec-download-view' object.format_spec.uuid %}" target="_blank" rel="noopener noreferrer">
       {{ object.format_spec }}</a></li>
   <li>Entity:
     <a href="{% url 'entity-view' object.parent_entity.uuid %}">

--- a/browse/views.py
+++ b/browse/views.py
@@ -141,9 +141,14 @@ class FormatSpecificationDownloadView(View):
 
         data = file_data.read()
         resp = HttpResponse(data, content_type=cur_object.doc_mime_type)
-        resp["Content-Disposition"] = 'attachment; filename="{0}"'.format(
-            Path(cur_object.doc_file_name).name
-        )
+
+        if cur_object.doc_file_name is not None and cur_object.doc_file_name != "":
+            file_name = Path(cur_object.doc_file_name).name
+        else:
+            file_name = cur_object.document_ref + mimetypes.guess_extension(
+                cur_object.doc_mime_type
+            )
+        resp["Content-Disposition"] = 'filename="{0}"'.format(file_name)
         return resp
 
 


### PR DESCRIPTION
Format specification documents are now opened in a separate window, without losing the original window. If no file name is assigned to them, a sensible one will be picked by the program.
