### PR TITLE
Make JSON of single releases slimmer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+-   Add the switches `--skip-empty-quantities` and `--skip-empty-entities` to the `export` command [#100](https://github.com/ziotom78/instrumentdb/pull/100)
+
 -   Add a new API to access entities and quantities through their path [#98](https://github.com/ziotom78/instrumentdb/pull/98)
 
 -   Make the download of specification documents easier [#97](https://github.com/ziotom78/instrumentdb/pull/97)

--- a/browse/management/commands/export.py
+++ b/browse/management/commands/export.py
@@ -55,6 +55,24 @@ it is not present, all releases will be included in the output.
 """,
         )
         parser.add_argument(
+            "--skip-empty-entities",
+            action="store_true",
+            help="""
+If set, skip all those entities that have no sub-entities nor
+quantities. See also --skip-empty-quantities.
+""",
+        )
+        parser.add_argument(
+            "--skip-empty-quantities",
+            action="store_true",
+            help="""
+If set, skip all those quantities that have no data files.
+(This can be useful if you are using --release=REL to
+export just one release, as some quantities might have been
+included because of a different release.)
+""",
+        )
+        parser.add_argument(
             "output_path",
             help="""
 Directory where to store the contents of the database.
@@ -70,6 +88,8 @@ If the folder does not exist, it will be created.""",
                 output_format=DumpOutputFormat.JSON
                 if options["json"]
                 else DumpOutputFormat.YAML,
+                skip_empty_quantities=options["skip_empty_quantities"],
+                skip_empty_entities=options["skip_empty_entities"],
                 only_tree=options["only_tree"],
                 output_folder=Path(options["output_path"]),
             ),

--- a/browse/management/commands/export.py
+++ b/browse/management/commands/export.py
@@ -95,3 +95,5 @@ If the folder does not exist, it will be created.""",
             ),
             release_tag=options["release"],
         )
+
+        # TODO: export format specifications, release documents, data files, etc.

--- a/browse/models.py
+++ b/browse/models.py
@@ -473,6 +473,7 @@ class Release(models.Model):
                     only_tree=False,
                     exist_ok=True,
                     skip_empty_quantities=False,
+                    skip_empty_entities=False,
                     output_format=DumpOutputFormat.JSON,
                     output_folder=temp_path,
                 ),

--- a/browse/models.py
+++ b/browse/models.py
@@ -472,6 +472,7 @@ class Release(models.Model):
                     no_attachments=True,
                     only_tree=False,
                     exist_ok=True,
+                    skip_empty_quantities=False,
                     output_format=DumpOutputFormat.JSON,
                     output_folder=temp_path,
                 ),
@@ -500,6 +501,8 @@ class ReleaseDumpConfiguration:
     no_attachments: bool
     only_tree: bool
     exist_ok: bool
+    skip_empty_entities: bool
+    skip_empty_quantities: bool
     output_format: DumpOutputFormat
     output_folder: Path
 
@@ -579,9 +582,23 @@ def save_attachment(configuration: ReleaseDumpConfiguration, relative_path, file
             outf.write(data)
 
 
-def dump_entity_tree(configuration: ReleaseDumpConfiguration, entities):
+def dump_entity_tree(configuration: ReleaseDumpConfiguration, entities, data_files):
     result = []
     for cur_entity in entities:
+        if configuration.skip_empty_entities:
+            quantities = Quantity.objects.filter(parent_entity=cur_entity)
+            num_of_data_files = 0
+            for cur_quantity in quantities:
+                num_of_data_files += len(
+                    cur_quantity.data_files.filter(uuid__in=data_files.all())
+                )
+
+            if not cur_entity.get_children() and num_of_data_files == 0:
+                logging.info(
+                    f"Skipping {cur_entity.name} as it has no children nor quantities"
+                )
+                continue
+
         # We use a OrderedDict here because otherwise "children" would
         # be the first key in the JSON file, and this would make the
         # file harder to read
@@ -593,7 +610,9 @@ def dump_entity_tree(configuration: ReleaseDumpConfiguration, entities):
         children = cur_entity.get_children()
         if children:
             # Descend the tree recursively
-            new_element["children"] = dump_entity_tree(configuration, children)
+            new_element["children"] = dump_entity_tree(
+                configuration, children, data_files
+            )
 
         result.append(new_element)
 
@@ -626,9 +645,18 @@ def dump_specifications(configuration: ReleaseDumpConfiguration, specs):
     return result
 
 
-def dump_quantities(configuration: ReleaseDumpConfiguration, quantities):
+def dump_quantities(configuration: ReleaseDumpConfiguration, quantities, data_files):
     result = []
     for cur_quantity in quantities:
+        if configuration.skip_empty_quantities and (
+            len(cur_quantity.data_files.filter(uuid__in=data_files.all())) < 1
+        ):
+            # This quantity has no data files
+            logging.info(
+                "Skipping quantity '%s' as it has no data files", cur_quantity.name
+            )
+            continue
+
         cur_entry = OrderedDict(
             [
                 ("uuid", Quoted(cur_quantity.uuid)),
@@ -738,7 +766,12 @@ def save_schema(
                     ]
                 ),
             ),
-            ("entities", dump_entity_tree(configuration, Entity.objects.root_nodes())),
+            (
+                "entities",
+                dump_entity_tree(
+                    configuration, Entity.objects.root_nodes(), data_files=data_files
+                ),
+            ),
             (
                 "format_specifications",
                 {}
@@ -747,7 +780,14 @@ def save_schema(
                     configuration, FormatSpecification.objects.all()
                 ),
             ),
-            ("quantities", dump_quantities(configuration, Quantity.objects.all())),
+            (
+                "quantities",
+                dump_quantities(
+                    configuration=configuration,
+                    quantities=Quantity.objects.all(),
+                    data_files=data_files,
+                ),
+            ),
             (
                 "data_files",
                 {}

--- a/tests/test_import_commands.py
+++ b/tests/test_import_commands.py
@@ -17,11 +17,12 @@ def check_db_size(
 
 
 class TestNestedYamlIO(TestCase):
-    def test_import_nested_yaml(self):
-        input_file = Path(__file__).parent / ".." / "examples" / "schema1.yaml"
+    def setUp(self):
+        self.input_file = Path(__file__).parent / ".." / "examples" / "schema1.yaml"
 
+    def test_import_nested_yaml_dry_run(self):
         # Test a dry run
-        call_command("import", "--dry-run", input_file)
+        call_command("import", "--dry-run", self.input_file)
         check_db_size(
             self,
             entity_len=0,
@@ -31,8 +32,9 @@ class TestNestedYamlIO(TestCase):
             release_len=0,
         )
 
+    def test_import_nested_yaml(self):
         # Test a normal import
-        call_command("import", input_file)
+        call_command("import", self.input_file)
         check_db_size(
             self,
             entity_len=12,
@@ -42,8 +44,9 @@ class TestNestedYamlIO(TestCase):
             release_len=1,
         )
 
+    def test_import_nested_yaml_no_overwrite(self):
         # Test that --no-overwrite works
-        call_command("import", "--no-overwrite", input_file)
+        call_command("import", "--no-overwrite", self.input_file)
         check_db_size(
             self,
             entity_len=12,


### PR DESCRIPTION
This PR adds the two switches `--skip-empty-quantities` and `--skip-empty-entities` to the `export` command. Their purpose is to avoid exporting those quantities/entities that are “empty”, i.e., which have no children.

-   With respect to a “quantity”, having no children means that there is no data file associated with that quantity.
-   Regarding an “entity”, it is empty if it has no children and none of its quantities has data files.

This is useful if you happen to change the name of some entity (e.g., the name of a detector) because you switched the naming scheme. In these cases, the tree of entities will have both the old and the new name for the detector, but once you want to export one release of the IMO (e.g., version 2.03), that release will just contain either the old or the new name but not both. Using `--skip-empty-quantities` and `--skip-empty-entities`, only the entities and quantities related with the “right” detector name will be exported.
