### PR TITLE
Properly export plot files instead of data files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+-   Fix an error in `manage.py export` when plot files are present [#112](https://github.com/ziotom78/instrumentdb/pull/112)
+
 -   Be more robust against `git`'s output [#111](https://github.com/ziotom78/instrumentdb/pull/111)
 
 -   Better handle missing `metadata` fields in data files [#110](https://github.com/ziotom78/instrumentdb/pull/110)

--- a/browse/models.py
+++ b/browse/models.py
@@ -728,7 +728,7 @@ def dump_data_files(configuration: ReleaseDumpConfiguration, data_files):
             dest_path = Path("plot_files") / full_plot_file_path(cur_data_file, "").name
             cur_entry["plot_file"] = Quoted(dest_path)
             cur_entry["plot_mime_type"] = Quoted(cur_data_file.plot_mime_type)
-            save_attachment(configuration, dest_path, cur_data_file.file_data)
+            save_attachment(configuration, dest_path, cur_data_file.plot_file)
 
         if cur_data_file.dependencies:
             cur_entry["dependencies"] = [


### PR DESCRIPTION
Because of an error in the code, plot files were not exported by the `manage.py export` command; instead, data files were exported twice. This PR fixes the issue.
