### PR TITLE
Create a RESTful API endpoint for downloading files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+-   Add RESTful API endpoints for downloading files [#131](https://github.com/ziotom78/instrumentdb/pull/131)
+
 # Version 2.0.2
 
 -   Make sure that unauthorized users cannot browse the contents of the database [#128](https://github.com/ziotom78/instrumentdb/pull/128)

--- a/browse/serializers.py
+++ b/browse/serializers.py
@@ -55,7 +55,7 @@ class FormatSpecificationSerializer(serializers.HyperlinkedModelSerializer):
             instance
         )
         representation["download_link"] = reverse(
-            "format-spec-download-view",
+            "formatspecification-download",
             kwargs={"pk": instance.uuid},
             request=self.context["request"],
         )
@@ -177,16 +177,19 @@ class DataFileSerializer(serializers.HyperlinkedModelSerializer):
     def to_representation(self, instance):
         representation = super(DataFileSerializer, self).to_representation(instance)
 
-        representation["download_link"] = reverse(
-            "data-file-download-view",
-            kwargs={"pk": instance.uuid},
-            request=self.context["request"],
-        )
-        representation["plot_download_link"] = reverse(
-            "data-file-plot-view",
-            kwargs={"pk": instance.uuid},
-            request=self.context["request"],
-        )
+        if instance.file_data:
+            representation["download_link"] = reverse(
+                "datafile-download",
+                kwargs={"pk": instance.uuid},
+                request=self.context["request"],
+            )
+
+        if instance.plot_file:
+            representation["plot_download_link"] = reverse(
+                "datafile-plot",
+                kwargs={"pk": instance.uuid},
+                request=self.context["request"],
+            )
 
         return representation
 


### PR DESCRIPTION
The RESTful API use authentication tokens, which are not compatible with the browser-based login page. Therefore, whenever a user wants to download a data file or a specification document using REST commands, the HTTP login page is returned instead.

This PR implements new REST API endpoints for the following cases:

1. Data files
2. Plot files associated with data files
3. Format specification documents

The change should be 100% transparent to the end user, as the new endpoints are returned by the Django RESTful views.

